### PR TITLE
Consolidate WireGuard facts into reusable role

### DIFF
--- a/ansible/roles/node/tasks/iperf.yml
+++ b/ansible/roles/node/tasks/iperf.yml
@@ -1,4 +1,9 @@
----
+- name: WireGuard | Consolidate host facts
+  ansible.builtin.include_role:
+    name: wireguard_facts
+  apply:
+    tags: [node, node_iperf, iperf3, wireguard, wg_facts]
+
 - name: Iperf3 | Install server package
   when: node_iperf_enable | bool
   ansible.builtin.package:
@@ -14,16 +19,6 @@
     enabled: false
     masked: true
   tags: [node_iperf, iperf3]
-
-- name: Node | Derive WG IP from vpn_nodes when missing
-  ansible.builtin.set_fact:
-    wg_ip: >-
-      {{ (vpn_nodes | selectattr('name', 'equalto', inventory_hostname) | map(attribute='wg_ip') | first) }}
-  when:
-    - wg_ip is not defined
-    - vpn_nodes is defined
-    - (vpn_nodes | selectattr('name', 'equalto', inventory_hostname) | list | length) > 0
-  tags: [node]
 
 # Если bind IP явно задан в vars — используем его; иначе берём wg_ip (если есть)
 - name: Node | Compute effective bind IP for iperf3
@@ -66,23 +61,6 @@
   tags: [node_iperf, iperf3]
 
 # --- Resolve hub WG IP for firewall rules ---
-- name: Iperf3 | Derive hub WG IP (effective)
-  when:
-    - node_iperf_enable | bool
-    - _ufw.stat.exists
-    - node_iperf_ufw_from_hub_only | bool
-  ansible.builtin.set_fact:
-    hub_wg_ip_effective: >-
-      {{
-        hub_wg_ip
-        | default( (groups['hub'] | first) | default('') | ternary(
-            hostvars[groups['hub'][0]].hub_wg_ip
-            | default(hostvars[groups['hub'][0]].wg_ip | default('')),
-            ''
-          ))
-      }}
-  tags: [node_iperf, iperf3]
-
 - name: Iperf3 | Assert hub WG IP is known
   when:
     - node_iperf_enable | bool
@@ -119,7 +97,7 @@
     rule: allow
     proto: tcp
     port: "{{ node_iperf_port }}"
-    from_ip: "{{ (wg_ip | regex_replace('\\.\\d+$', '.0')) ~ '/24' }}"
+    from_ip: "{{ wg_subnet_cidr }}"
     comment: "iperf3 server (bind {{ node_iperf_bind_ip_effective | default('0.0.0.0') }})"
   tags: [node_iperf, iperf3]
 

--- a/ansible/roles/node_exporter/tasks/main.yml
+++ b/ansible/roles/node_exporter/tasks/main.yml
@@ -1,12 +1,8 @@
----
-- name: Derive wg_ip from vpn_nodes by inventory_hostname (if not set)
-  ansible.builtin.set_fact:
-    wg_ip: >-
-      {{ (vpn_nodes | selectattr('name', 'equalto', inventory_hostname) | list | first).wg_ip }}
-  when:
-    - wg_ip is not defined
-    - vpn_nodes is defined
-    - (vpn_nodes | selectattr('name', 'equalto', inventory_hostname) | list | length) > 0
+- name: WireGuard | Consolidate host facts
+  ansible.builtin.include_role:
+    name: wireguard_facts
+  apply:
+    tags: [node_exporter, wireguard, wg_facts]
 
 - name: Install and run node_exporter (single @instance on WG IP)
   tags: [node_exporter]
@@ -127,5 +123,5 @@
         rule: allow
         proto: tcp
         port: "{{ node_exporter_port }}"
-        from_ip: "{{ (wg_ip | regex_replace('\\.\\d+$', '.0')) }}/24"
+        from_ip: "{{ wg_subnet_cidr }}"
         comment: "node_exporter @{{ node_exporter_listen }}"

--- a/ansible/roles/wireguard_facts/tasks/main.yml
+++ b/ansible/roles/wireguard_facts/tasks/main.yml
@@ -1,0 +1,68 @@
+---
+- name: WireGuard facts | Lookup vpn_nodes entry for this host
+  vars:
+    _matches: "{{ vpn_nodes | default([]) | selectattr('name', 'equalto', inventory_hostname) | list }}"
+  ansible.builtin.set_fact:
+    wireguard_node_entry: "{{ _matches[0] }}"
+  when:
+    - vpn_nodes is defined
+    - wireguard_node_entry is not defined
+    - _matches | length > 0
+  tags: [wireguard, wg_facts]
+
+- name: WireGuard facts | Derive wg_ip from entry
+  ansible.builtin.set_fact:
+    wg_ip: "{{ wireguard_node_entry.wg_ip }}"
+  when:
+    - wg_ip is not defined
+    - wireguard_node_entry is defined
+    - wireguard_node_entry.wg_ip is defined
+  tags: [wireguard, wg_facts]
+
+- name: WireGuard facts | Normalize wg_ip to string
+  ansible.builtin.set_fact:
+    wg_ip: "{{ wg_ip | string }}"
+  when:
+    - wg_ip is defined
+  tags: [wireguard, wg_facts]
+
+- name: WireGuard facts | Derive /24 subnet cidr from wg_ip
+  ansible.builtin.set_fact:
+    wg_subnet_cidr: "{{ (wg_ip | regex_replace('\\.\\d+$', '.0')) }}/24"
+  when:
+    - wg_ip is defined
+    - (wg_ip | length) > 0
+  tags: [wireguard, wg_facts]
+
+- name: WireGuard facts | Remember hub inventory host (if any)
+  ansible.builtin.set_fact:
+    wireguard_hub_inventory_host: "{{ groups['hub'][0] }}"
+  when:
+    - wireguard_hub_inventory_host is not defined
+    - 'hub' in groups
+    - (groups['hub'] | length) > 0
+  tags: [wireguard, wg_facts]
+
+- name: WireGuard facts | Derive effective hub wg_ip
+  vars:
+    _hub_candidate: "{{ wireguard_hub_inventory_host | default('') }}"
+    _hub_ip_guess: "{{ hostvars[_hub_candidate].hub_wg_ip | default(hostvars[_hub_candidate].wg_ip | default('')) if (_hub_candidate | length > 0) else '' }}"
+  ansible.builtin.set_fact:
+    hub_wg_ip_effective: "{{ hub_wg_ip | default(_hub_ip_guess) }}"
+  when:
+    - hub_wg_ip_effective is not defined
+    - ((hub_wg_ip is defined) and (hub_wg_ip | length) > 0) or (_hub_ip_guess | length) > 0
+  tags: [wireguard, wg_facts]
+
+- name: WireGuard facts | Provide /32 hub cidr helper
+  ansible.builtin.set_fact:
+    hub_wg_ip_cidr32: "{{ hub_wg_ip_effective }}/32"
+  when:
+    - hub_wg_ip_effective is defined
+    - (hub_wg_ip_effective | length) > 0
+  tags: [wireguard, wg_facts]
+
+- name: WireGuard facts | Mark consolidation complete
+  ansible.builtin.set_fact:
+    wireguard_facts_loaded: true
+  tags: [wireguard, wg_facts]

--- a/ansible/roles/wireguard_node/tasks/main.yml
+++ b/ansible/roles/wireguard_node/tasks/main.yml
@@ -46,14 +46,11 @@
       ansible.builtin.set_fact:
         node_wg_pubkey: "{{ node_pub_raw.content | b64decode | trim }}"
 
-    - name: Derive wg_ip from vpn_nodes by inventory_hostname (if not set)
-      ansible.builtin.set_fact:
-        wg_ip: >-
-          {{ (vpn_nodes | selectattr('name', 'equalto', inventory_hostname) | first).wg_ip }}
-      when:
-        - wg_ip is not defined
-        - vpn_nodes is defined
-        - (vpn_nodes | selectattr('name', 'equalto', inventory_hostname) | list | length) > 0
+    - name: WireGuard | Consolidate host facts
+      ansible.builtin.include_role:
+        name: wireguard_facts
+      apply:
+        tags: [wg, wireguard, wg_facts]
 
     - name: Assert wg_ip is defined for this node
       ansible.builtin.assert:

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -1,0 +1,26 @@
+# Code Review Summary
+
+## Critical / Bug-Risk Issues
+
+1. **Docker architecture mapping can break on unknown architectures.**  
+   The architecture lookup in the Docker role indexes a hard-coded dictionary directly with `ansible_facts.architecture`. If an unexpected architecture string arrives (for example `riscv64` or `loongarch64`), Jinja will raise an `UndefinedError` before the `default` filter is applied, aborting the play. Prefer using `dict.get(key, default)` or the `default` filter on the whole expression instead of the indexed lookup. 【F:ansible/roles/docker/tasks/main.yml†L33-L47】
+
+2. **Hub IP derivation assumes the `hub` inventory group always exists.**  
+   The iperf tasks index `groups['hub'][0]` directly; when the `hub` group is missing (for example in standalone-node smoke tests) the play will fail even though the firewall task is skipped. Wrap the access in `groups.get('hub', [])` and guard the lookup before dereferencing. 【F:ansible/roles/node/tasks/iperf.yml†L68-L123】
+
+3. **Basic-auth password handling is logged in plain text.**  
+   The htpasswd loop explicitly sets `no_log: false`, causing user passwords (or their hashed form) to be emitted into Ansible logs. Set `no_log: true` (or remove the override entirely) to keep secrets out of logs. 【F:ansible/roles/nginx/tasks/main.yml†L51-L101】
+
+## Refactoring Opportunities
+
+1. **Consolidate WireGuard IP discovery logic.**  
+   Both the node and node_exporter roles repeat the same `wg_ip` lookup from `vpn_nodes`. Consider moving this into a reusable fact (e.g. via `set_fact` in `group_vars/all`, a role dependency, or a custom filter) so you only maintain the lookup in one place. 【F:ansible/roles/node/tasks/iperf.yml†L18-L37】【F:ansible/roles/node_exporter/tasks/main.yml†L1-L34】
+
+2. **Encapsulate UFW rule authoring.**  
+   Firewall rules for node services (iperf3, node_exporter, potentially others) are scattered across roles. Extracting them into a dedicated role or task file with parameters (port, comment, CIDR) will make adding new exporters easier and ensure consistent behavior.
+
+## Additional Suggestions
+
+- Add molecule/CI coverage for the edge cases above (missing hub group, alternative architectures) so regressions are caught automatically.
+- Where possible prefer `ansible.builtin.package` over `ansible.builtin.apt` to widen OS support; most tasks are Debian-specific but a package abstraction would reduce duplication if you later need RPM support.
+

--- a/docs/wireguard-roles.md
+++ b/docs/wireguard-roles.md
@@ -9,6 +9,7 @@
 
 - `ansible/roles/wireguard_hub/tasks/main.yml` — настройка **хаба**: ключи, сбор pubkey'ев узлов, рендер `/etc/wireguard/<iface>.conf`, UFW, запуск `wg-quick`.
 - `ansible/roles/wireguard_node/tasks/main.yml` — настройка **узла**: ключи, получение pubkey хаба, рендер `/etc/wireguard/<iface>.conf`, запуск `wg-quick`.
+- `ansible/roles/wireguard_facts` — **единая консолидация WireGuard-фактов**: ищет описание узла в `vpn_nodes`, задаёт `wg_ip`, `wg_subnet_cidr`, подставляет `hub_wg_ip_effective` и кэширует имя хаба.
 
 Роли вызываются из `ansible/site.yml` и удобнее запускать через цели Makefile (см. ниже).
 
@@ -62,7 +63,7 @@ vpn_nodes:
   #   role: "vpn"
 ```
 
-> Роль `wireguard_node` **не требует** `host_vars`: она находит `wg_ip` по записи в `vpn_nodes`, где `name == inventory_hostname`. Если записи нет — задача упадёт с понятной ошибкой (нужно добавить узел в `vpn_nodes`).
+> Факт `wg_ip` и связанные с ним вычисления (`wg_subnet_cidr`, `hub_wg_ip_effective`) собирает роль `wireguard_facts`. Она автоматически подключается из `wireguard_node`, `node_exporter`, `node:iperf` и доступна для переиспользования в других ролях.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a wireguard_facts helper role to resolve node and hub WireGuard facts from vpn_nodes
- update wireguard_node, node_exporter, and node iperf tasks to consume the shared facts and reuse the derived subnet helper
- document the shared role so other playbooks can reuse the consolidated facts

## Testing
- not run (ansible-playbook is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfb868a024832a8f5a8a2c55f01f21