### PR TITLE
feat(ansible): centralize UFW configuration via ufw_firewall role

### DIFF
--- a/ansible/roles/node/tasks/iperf.yml
+++ b/ansible/roles/node/tasks/iperf.yml
@@ -57,14 +57,14 @@
   when: node_iperf_enable | bool
   ansible.builtin.stat:
     path: /usr/sbin/ufw
-  register: _ufw
+  register: iperf_ufw
   tags: [node_iperf, iperf3]
 
 # --- Resolve hub WG IP for firewall rules ---
 - name: Iperf3 | Assert hub WG IP is known
   when:
     - node_iperf_enable | bool
-    - _ufw.stat.exists
+    - iperf_ufw is defined and iperf_ufw.stat.exists
     - node_iperf_ufw_from_hub_only | bool
   ansible.builtin.assert:
     that:
@@ -75,30 +75,35 @@
       or set `hub_wg_ip`/`wg_ip` for the host in group 'hub'.
   tags: [node_iperf, iperf3]
 
-- name: Iperf3 | UFW allow from HUB /32 (WG only)
-  when:
-    - node_iperf_enable | bool
-    - _ufw.stat.exists
-    - node_iperf_ufw_from_hub_only | bool
-  community.general.ufw:
-    rule: allow
-    proto: tcp
-    port: "{{ node_iperf_port }}"
-    from_ip: "{{ hub_wg_ip_effective }}/32"
-    comment: "iperf3 server (bind {{ node_iperf_bind_ip_effective | default('0.0.0.0') }})"
-  tags: [node_iperf, iperf3]
-
-- name: Iperf3 | UFW allow from node WG /24 (not hub-only)
-  when:
-    - node_iperf_enable | bool
-    - _ufw.stat.exists
-    - not (node_iperf_ufw_from_hub_only | bool)
-  community.general.ufw:
-    rule: allow
-    proto: tcp
-    port: "{{ node_iperf_port }}"
-    from_ip: "{{ wg_subnet_cidr }}"
-    comment: "iperf3 server (bind {{ node_iperf_bind_ip_effective | default('0.0.0.0') }})"
+- name: Iperf3 | Configure ufw allowances
+  when: node_iperf_enable | bool and (iperf_ufw is defined and iperf_ufw.stat.exists)
+  ansible.builtin.include_role:
+    name: ufw_firewall
+  vars:
+    ufw_firewall_rules: >-
+      {{
+        (node_iperf_ufw_from_hub_only | bool)
+        | ternary(
+            [
+              {
+                'rule': 'allow',
+                'proto': 'tcp',
+                'port': node_iperf_port | string,
+                'from_ip': hub_wg_ip_effective ~ '/32',
+                'comment': 'iperf3 server (bind ' ~ (node_iperf_bind_ip_effective | default('0.0.0.0')) ~ ')'
+              }
+            ],
+            [
+              {
+                'rule': 'allow',
+                'proto': 'tcp',
+                'port': node_iperf_port | string,
+                'from_ip': wg_subnet_cidr,
+                'comment': 'iperf3 server (bind ' ~ (node_iperf_bind_ip_effective | default('0.0.0.0')) ~ ')'
+              }
+            ]
+          )
+      }}
   tags: [node_iperf, iperf3]
 
 # # --- Firewall allowances for iperf3 over WG ---

--- a/ansible/roles/node_exporter/tasks/main.yml
+++ b/ansible/roles/node_exporter/tasks/main.yml
@@ -112,16 +112,13 @@
         enabled: true
         state: started
 
-    - name: Detect ufw presence
-      ansible.builtin.stat:
-        path: /usr/sbin/ufw
-      register: ufw_present
-
-    - name: Allow node_exporter from WG subnet via ufw
-      when: ufw_present.stat.exists
-      community.general.ufw:
-        rule: allow
-        proto: tcp
-        port: "{{ node_exporter_port }}"
-        from_ip: "{{ wg_subnet_cidr }}"
-        comment: "node_exporter @{{ node_exporter_listen }}"
+    - name: Configure ufw for node_exporter
+      ansible.builtin.include_role:
+        name: ufw_firewall
+      vars:
+        ufw_firewall_rules:
+          - rule: allow
+            proto: tcp
+            port: "{{ node_exporter_port }}"
+            from_ip: "{{ wg_subnet_cidr }}"
+            comment: "node_exporter @{{ node_exporter_listen }}"

--- a/ansible/roles/ufw_firewall/defaults/main.yml
+++ b/ansible/roles/ufw_firewall/defaults/main.yml
@@ -1,0 +1,2 @@
+# List of UFW rules to apply. Each item is passed directly to community.general.ufw.
+ufw_firewall_rules: []

--- a/ansible/roles/ufw_firewall/tasks/main.yml
+++ b/ansible/roles/ufw_firewall/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Detect ufw presence
+  ansible.builtin.stat:
+    path: /usr/sbin/ufw
+  register: ufw_firewall_ufw
+
+- name: Apply configured ufw firewall rules
+  when:
+    - ufw_firewall_ufw.stat.exists
+    - (ufw_firewall_rules | default([])) | length > 0
+  community.general.ufw: "{{ item }}"
+  loop: "{{ ufw_firewall_rules | default([]) }}"
+  loop_control:
+    label: >-
+      {{ item.comment | default(item.name | default(item.port | default(item.rule | default('rule')))) }}

--- a/ansible/roles/wireguard_hub/tasks/main.yml
+++ b/ansible/roles/wireguard_hub/tasks/main.yml
@@ -106,18 +106,15 @@
         mode: "0600"
       notify: Restart wg-quick
 
-    - name: Detect ufw presence
-      ansible.builtin.stat:
-        path: /usr/sbin/ufw
-      register: ufw_present
-
-    - name: Allow WireGuard UDP port in ufw (if present)
-      community.general.ufw:
-        rule: allow
-        proto: udp
-        port: "{{ wg_listen_port }}"
-        comment: "WireGuard {{ wg_iface }}"
-      when: ufw_present.stat.exists
+    - name: Configure ufw for WireGuard hub
+      ansible.builtin.include_role:
+        name: ufw_firewall
+      vars:
+        ufw_firewall_rules:
+          - rule: allow
+            proto: udp
+            port: "{{ wg_listen_port }}"
+            comment: "WireGuard {{ wg_iface }}"
 
     - name: Enable + start wg interface
       ansible.builtin.systemd:


### PR DESCRIPTION
## Summary
- introduce a dedicated `ufw_firewall` role that applies configured UFW rules
- switch node exporter, iperf, and wireguard hub tasks to reuse the new role for firewall configuration

## Testing
- not run (infrastructure change)


------
https://chatgpt.com/codex/tasks/task_e_68dfffba4da8832a855796b99795f8ca